### PR TITLE
Fixes for list continuation

### DIFF
--- a/LinkingEditor.m
+++ b/LinkingEditor.m
@@ -2054,19 +2054,19 @@ static long (*GetGetScriptManagerVariablePointer())(short) {
 
 
 - (NSString *)pairedCharacterForString:(NSString *)pairString{
-    if ([pairString isEqualToString:@"]"]) {
+    if ([@"]" isEqualToString:pairString]) {
         return @"n";
-    }else if ([pairString isEqualToString:@")"]) {
+    }else if ([@")" isEqualToString:pairString]) {
         return @"n";
-    }else if ([pairString isEqualToString:@"}"]) {
+    }else if ([@"}" isEqualToString:pairString]) {
         return @"n";
-    }else if ([pairString isEqualToString:@"["]) {
+    }else if ([@"[" isEqualToString:pairString]) {
         return @"]";
-    }else if ([pairString isEqualToString:@"("]) {
+    }else if ([@"(" isEqualToString:pairString]) {
         return @")";
-    }else if ([pairString isEqualToString:@"{"]) {
+    }else if ([@"{" isEqualToString:pairString]) {
         return @"}";
-    }else if ([pairString isEqualToString:@"\""]) {
+    }else if ([@"\"" isEqualToString:pairString]) {
         return @"\"";
     }
     return @"";


### PR DESCRIPTION
The feature where a bullet would be auto-inserted on the following line was only working if there was at least one whitespace character preceding the bullet. The first commit here fixes that, so no leading whitespace is necessary.

The second commit fixes an issue with undo related to the same feature. Specifically, when you hit enter on an empty list item to delete the bullet, the deletion was bypassing the undo manager. As a result, a subsequent undo would delete additional characters and behave weirdly.

The third commit isn't related to list continuation, but it just happened to be an exception occurring in the same file that I noticed while testing the other fixes.
