### PR TITLE
Refine services description in Info.plist

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -207,28 +207,12 @@
 				<string>public.rtf</string>
 				<string>public.plain-text</string>
 			</array>
-		</dict>
-		<dict>
-			<key>NSKeyEquivalent</key>
-			<dict>
-				<key>default</key>
-				<string>V</string>
-			</dict>
-			<key>NSMenuItem</key>
-			<dict>
-				<key>default</key>
-				<string>nvALT: New Note from File</string>
-			</dict>
-			<key>NSMessage</key>
-			<string>createFromSelection</string>
-			<key>NSPortName</key>
-			<string>nvALT</string>
 			<key>NSSendFileTypes</key>
 			<array>
 				<string>public.text</string>
-				<string>com.adobe.pdf</string>
-				<string>com.apple.webarchive</string>
 				<string>com.apple.rtfd</string>
+				<string>com.apple.webarchive</string>
+				<string>com.adobe.pdf</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
This addresses some of the issues I described [here](https://github.com/scrod/nv/issues/200) two years ago.

The main improvement is that the "New Note from Selection" services entry will (in a file-based context, e.g., Finder) only show up for files that are of a supported type (i.e., text, RTF, PDF, HTML).

Note that there could be some compatibility issues with this on pre-10.6 machines. I haven't tested it, but from my limited understanding of Apple's docs:
- On 10.4, the services item won't register at all.
- On 10.5, the services item will register for text selections, but it won't show up for files.

I'm not sure if this is an issue, though, since nvALT seems to be headed toward a 10.6 minimum requirement anyway, and services weren't terribly usable prior to 10.6 anyway.
