### PR TITLE
Remove unused DroplrKit

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "DroplrKit"]
-	path = DroplrKit
-	url = git@github.com:Droplr/api-objc.git

--- a/Notation.xcodeproj/project.pbxproj
+++ b/Notation.xcodeproj/project.pbxproj
@@ -260,8 +260,6 @@
 		934C3FB514FDA06A000D14BA /* templateclean.html in Resources */ = {isa = PBXBuildFile; fileRef = 934C3FB114FDA069000D14BA /* templateclean.html */; };
 		934C3FB914FDA74F000D14BA /* NSFileManager+DirectoryLocations.m in Sources */ = {isa = PBXBuildFile; fileRef = 934C3FB814FDA74F000D14BA /* NSFileManager+DirectoryLocations.m */; };
 		937E6783138C250E0099DF47 /* AutoHyperlinks.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 937E6781138C24980099DF47 /* AutoHyperlinks.framework */; };
-		93833D6C15A5DFCA00FA2892 /* Classes in Resources */ = {isa = PBXBuildFile; fileRef = 93833D6A15A5DFCA00FA2892 /* Classes */; };
-		93833D6D15A5DFCA00FA2892 /* External in Resources */ = {isa = PBXBuildFile; fileRef = 93833D6B15A5DFCA00FA2892 /* External */; };
 		93A158BC133C304D00E1E7DA /* Markdownify.nvhelp in Resources */ = {isa = PBXBuildFile; fileRef = 93A158BB133C304D00E1E7DA /* Markdownify.nvhelp */; };
 		93A158BE133C497400E1E7DA /* Notality.icns in Resources */ = {isa = PBXBuildFile; fileRef = 93A158BD133C497400E1E7DA /* Notality.icns */; };
 		93B348281371547800658F98 /* HUDIconLock.png in Resources */ = {isa = PBXBuildFile; fileRef = 93B348241371547800658F98 /* HUDIconLock.png */; };
@@ -769,8 +767,6 @@
 		934C3FB714FDA74F000D14BA /* NSFileManager+DirectoryLocations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSFileManager+DirectoryLocations.h"; sourceTree = "<group>"; };
 		934C3FB814FDA74F000D14BA /* NSFileManager+DirectoryLocations.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSFileManager+DirectoryLocations.m"; sourceTree = "<group>"; };
 		937E6781138C24980099DF47 /* AutoHyperlinks.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = AutoHyperlinks.framework; sourceTree = "<group>"; };
-		93833D6A15A5DFCA00FA2892 /* Classes */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Classes; path = DroplrKit/DroplrKit/Classes; sourceTree = "<group>"; };
-		93833D6B15A5DFCA00FA2892 /* External */ = {isa = PBXFileReference; lastKnownFileType = folder; name = External; path = DroplrKit/DroplrKit/External; sourceTree = "<group>"; };
 		93A158BB133C304D00E1E7DA /* Markdownify.nvhelp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Markdownify.nvhelp; sourceTree = "<group>"; };
 		93A158BD133C497400E1E7DA /* Notality.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = Notality.icns; sourceTree = "<group>"; };
 		93B348241371547800658F98 /* HUDIconLock.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = HUDIconLock.png; path = Images/HUDIconLock.png; sourceTree = "<group>"; };
@@ -1220,7 +1216,6 @@
 		29B97315FDCFA39411CA2CEA /* Other Sources */ = {
 			isa = PBXGroup;
 			children = (
-				93833D6815A5DF4500FA2892 /* DroplrKit */,
 				93B90E7D138601C100BEC5FB /* ODBEditor */,
 				5C96F5A8131C379200A2E4AC /* Markup */,
 				5CA10FFA131C2A7600DE1F91 /* readability */,
@@ -1357,15 +1352,6 @@
 				5CA11003131C2A7600DE1F91 /* url_helpers.pyc */,
 			);
 			path = readability;
-			sourceTree = "<group>";
-		};
-		93833D6815A5DF4500FA2892 /* DroplrKit */ = {
-			isa = PBXGroup;
-			children = (
-				93833D6A15A5DFCA00FA2892 /* Classes */,
-				93833D6B15A5DFCA00FA2892 /* External */,
-			);
-			name = DroplrKit;
 			sourceTree = "<group>";
 		};
 		93B90E7D138601C100BEC5FB /* ODBEditor */ = {
@@ -1582,8 +1568,6 @@
 				934C3FB314FDA06A000D14BA /* customclean.css in Resources */,
 				934C3FB414FDA06A000D14BA /* template.html in Resources */,
 				934C3FB514FDA06A000D14BA /* templateclean.html in Resources */,
-				93833D6C15A5DFCA00FA2892 /* Classes in Resources */,
-				93833D6D15A5DFCA00FA2892 /* External in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Not sure if it was public and was pulled, but the submodule introduced in 95daa70 doesn't seem to be publicly accessible. https://github.com/Droplr reports "Droplr doesn’t have any public repositories yet."

It looks like the project compiles and runs fine if I remove those files. Accidentally added?
