### PR TITLE
No longer says note is "1 words."

### DIFF
--- a/AppController.m
+++ b/AppController.m
@@ -2982,7 +2982,7 @@ terminateApp:
             NSUInteger theCount = [[[textView textStorage] words] count];
 
             if (theCount > 0) {
-                [wordCounter setStringValue:[[NSString stringWithFormat:@"%d", theCount] stringByAppendingString:@" words"]];
+                [wordCounter setStringValue:[[NSString stringWithFormat:@"%d", theCount] stringByAppendingString:theCount == 1 ? @" word" : @" words"]];
             }else {
                 [wordCounter setStringValue:@""];
             }


### PR DESCRIPTION
!["1 words"](http://zackary.me/1dPxq+)

In theory, this shouldn't happen anymore. I had trouble testing it out, though, so give it a whirl first.