### PR TITLE
Clarify that on-the-wire communication with Simplenote is encrypted

### DIFF
--- a/en.lproj/NotationPrefsView.nib/designable.nib
+++ b/en.lproj/NotationPrefsView.nib/designable.nib
@@ -171,7 +171,7 @@
                                     <textField verticalHuggingPriority="750" id="276">
                                         <rect key="frame" x="34" y="58" width="156" height="64"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                        <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Warning: Note contents will be delivered as clear text. Notes &gt;400k in size may have issues with sync." id="277">
+                                        <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Warning: Note contents will be encrypted with HTTPS during transmission, but stored in clear text. Notes &gt;400k in size may have issues with sync." id="277">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>


### PR DESCRIPTION
See #207 and #412. Note that this makes the wording slightly clearer than PR #412 did.